### PR TITLE
Make line break option more flexible

### DIFF
--- a/ipystata/ipystata_magic.py
+++ b/ipystata/ipystata_magic.py
@@ -323,7 +323,15 @@ class iPyStataMagic(Magics):
             print('Set the working directory of Stata to: %s' % python_cwd)
         if args.mata:
             code_list.append('mata:' + '\n')
-        code_list.append(re.sub(r"[ ]{1,}\/\/\/.*\n", " ", cell))
+        ## Remove line breaks
+        cell = re.sub(r"[ ]{1,}\/\/\/.*\n[\s]*", " ", cell)
+        ## Remove comments starting with //
+        cell = re.sub("[ ]{1,}\/\/.*", "", cell)
+        ## Remove comments between /* */
+        cell = re.sub("\/\*((.|\n)*)\*\/", "", cell)
+        ## Remove lines starting with *
+        cell = re.sub("(?m)^\*.*\n?", "", cell)
+        code_list.append(cell)
         if args.mata:
             code_list.append('end' + '\n')
         if args.output:

--- a/ipystata/ipystata_magic.py
+++ b/ipystata/ipystata_magic.py
@@ -323,7 +323,7 @@ class iPyStataMagic(Magics):
             print('Set the working directory of Stata to: %s' % python_cwd)
         if args.mata:
             code_list.append('mata:' + '\n')
-        code_list.append(re.sub(r"///\n", "", cell))
+        code_list.append(re.sub(r"[ ]{1,}\/\/\/.*\n", " ", cell))
         if args.mata:
             code_list.append('end' + '\n')
         if args.output:


### PR DESCRIPTION
I updated the line break option to match one to many spaces before `\\\` then everything until the new line. The line break plus comment is then replaced with a space, because the regex matches all the spaces before the line break.

This makes the line break detection more flexible and it will pick up code like this:

    args a /// input parameter for a
         b /// input parameter for b
         c

or

    args a                          /// input parameter for a
         b                          /// input parameter for b
         c

and replace it with `args a b c` as per [Stata manual](http://www.stata.com/manuals13/pcomments.pdf). (Note that it will not replace the spaces at the beginning of the new line but the original command did not do that too. I don't think it matters anyways).

I tested this and it seems to work without issues.