### PR TITLE
Add arguments for graph size

### DIFF
--- a/ipystata/ipystata_magic.py
+++ b/ipystata/ipystata_magic.py
@@ -136,6 +136,8 @@ class iPyStataMagic(Magics):
     @argument('-gm', '--getmacro', action='append', help='This will attempt to output the named macro values as a dictionary.')
     @argument('-gr', '--graph', action='store_true', default=False, help='This will classify the Stata cell as one that returns a graph.')
     @argument('-m', '--mata', action='store_true', default=False, help='This will classify the code in the cell as Mata code.')
+    @argument('-w', '--width', type=int, default=1000, help='Graph width.')
+    @argument('-h', '--height', type=int, default=800, help='Graph height.')
 
     @needs_local_scope
     @cell_magic
@@ -337,7 +339,7 @@ class iPyStataMagic(Magics):
         if args.output:
             code_list.append('quietly save "%s", replace ' % data_out + "\n")
         if args.graph:
-            code_list.append('quietly graph export "%s", replace width(1000) height(800) ' % graph_out + "\n")
+            code_list.append('quietly graph export "%s", replace width(%d) height(%d) ' % (graph_out, args.width, args.height) + "\n")
         code_txt= '\n'.join(code_list)
 
         ## Execute code and wait for the Stata session to finish.


### PR DESCRIPTION
Hi again!

I noticed that the graph size was hard coded and some of my graphs were being cut off.
I added two new arguments `-w / --width` and `-h / --height` that can be used to specify the size of the output. If they are not specified, the default values will be used (I kept them the same as the original hard coded values).

Now, graphing with the following command `%%stata --graph --width=250 --heigth=1400` will produce a graph that is `250x1400` pixels. 

I tested and it seems to work fine on my end. I tried both the long and short arguments.