### PR TITLE
Increase default linesize to 200 to prevent horizontal truncation 

### DIFF
--- a/ipystata/ipystata_magic.py
+++ b/ipystata/ipystata_magic.py
@@ -323,6 +323,7 @@ class iPyStataMagic(Magics):
             self.gph_info_dict[session_id] = {}
             self.do_dict[session_id]('log using "{}" , text replace'.format(self.log_dict[session_id]))
             self.do_dict[session_id]('set more off')
+            self.do_dict[session_id]('set linesize 200')
 
             pid_after = iPyStata.get_stata_pid()
             if len(pid_before) == 1 and pid_before == pid_after:


### PR DESCRIPTION
This kernel works great! Thanks!

This PR increases the `linesize` to 200 which was 80 by default. Larger `linesize` ensures the output won't be truncated horizontally.

It's particularly useful when we use `estout` that outputs many models, for example.

<img width="552" alt="Screenshot 2019-03-17 13 58 01" src="https://user-images.githubusercontent.com/22109923/54484544-e97f5b00-48bc-11e9-9cb3-70d21d0a68b3.png">

<img width="648" alt="Screenshot 2019-03-17 13 59 00" src="https://user-images.githubusercontent.com/22109923/54484546-f1d79600-48bc-11e9-8f60-4969583a2b34.png">

